### PR TITLE
Add more concise `state.files` description

### DIFF
--- a/test/App-test.js
+++ b/test/App-test.js
@@ -19,7 +19,7 @@ describe('<App />', function() {
   });
 
   describe('state.files', function() {
-    it('should be empty array', function() {
+    it('should be array with one empty string', function() {
       const wrapper = shallow(<App />);
       expect(wrapper.state('files')).toEqual(['']);
     });


### PR DESCRIPTION
'should be empty array' suggests that the test expects `state.files === []`. The proposed description may be a bit more concise.